### PR TITLE
Famous users sampling

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -25,6 +25,7 @@ class Person
   validates :gender, inclusion: { in: GENDERS }
 
   index({ target_source: 1, target_id: 1}, { unique: true })
+  index({ famous: 1 })
 
   has_many :tweets
   belongs_to :city

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -18,6 +18,7 @@ class Person
   field :target_source, type: String
   field :target_id, type: String
   field :target_name, type: String
+  field :famous, type: Boolean, default: false
   field :birth_year, type: Integer
   field :gender, type: String
 

--- a/app/models/tencent_agent.rb
+++ b/app/models/tencent_agent.rb
@@ -1,5 +1,7 @@
 class TencentAgent
   include Mongoid::Document
+  include Mongoid::Timestamps
+
   include TencentLogger
   include FamousUsersSampling
   include UsersSampling

--- a/app/models/tencent_agent.rb
+++ b/app/models/tencent_agent.rb
@@ -20,6 +20,8 @@ class TencentAgent
 
   field :api_calls_count, type: Integer, default: 0
 
+  scope :with_available_lists, where(full_with_lists: false)
+
   def get(path, params = {}, &block)
     access_token.get(path, params: params, &block).parsed
   end

--- a/app/models/tencent_agent.rb
+++ b/app/models/tencent_agent.rb
@@ -1,6 +1,7 @@
 class TencentAgent
   include Mongoid::Document
   include TencentLogger
+  include FamousUsersSampling
   include UsersSampling
   include UsersTracking
   include TweetsGathering

--- a/app/models/tencent_agent/famous_users_sampling.rb
+++ b/app/models/tencent_agent/famous_users_sampling.rb
@@ -1,0 +1,90 @@
+class TencentAgent
+  module FamousUsersSampling
+    extend ActiveSupport::Concern
+
+    FAMOUS_CLASSES = [
+      {classid: 101, name: '娱乐明星'},
+      {classid: 102, name: '体育明星'},
+      {classid: 103, name: '生活时尚'},
+      {classid: 104, name: '财经'},
+      {classid: 105, name: '科技网络'},
+      {classid: 106, name: '文化出版'},
+      {classid: 108, name: '汽车'},
+      {classid: 109, name: '动漫'},
+      {classid: 110, name: '游戏'},
+      {classid: 111, name: '星座命理'},
+      {classid: 112, name: '教育'},
+      {classid: 114, name: '企业品牌'},
+      {classid: 115, name: '酷站汇'},
+      {classid: 116, name: '腾讯产品'},
+      {classid: 228, name: '有趣用户'},
+      {classid: 267, name: '营销广告'},
+      {classid: 268, name: '媒体机构'},
+      {classid: 268, subclassid: 'subclass_959', name: '广播'},
+      {classid: 268, subclassid: 'subclass_960', name: '电视'},
+      {classid: 268, subclassid: 'subclass_961', name: '报纸'},
+      {classid: 268, subclassid: 'subclass_962', name: '杂志'},
+      {classid: 268, subclassid: 'subclass_963', name: '网络媒体'},
+      {classid: 268, subclassid: 'subclass_964', name: '通讯社'},
+      {classid: 294, name: '传媒人士'},
+      {classid: 294, subclassid: 'subclass_953', name: '传媒领袖'},
+      {classid: 294, subclassid: 'subclass_955', name: '名编名记'},
+      {classid: 294, subclassid: 'subclass_956', name: '主持人'},
+      {classid: 294, subclassid: 'subclass_957', name: '传媒学者'},
+      {classid: 294, subclassid: 'subclass_958', name: '专栏评论'},
+      {classid: 304, name: '政府机构'},
+      {classid: 363, name: '公益慈善'},
+      {classid: 945, name: '公务人员'},
+      {classid: 949, name: '快乐女声'},
+      {classid: 950, name: '公共名人'},
+      {classid: 951, name: '花儿朵朵'}
+    ]
+
+    SAMPLE_WAIT = 0.1
+
+    def sample_famous_users
+      info 'Sampling Famous Users...'
+
+      FAMOUS_CLASSES.each do |famous_class|
+        info %{Sampling famous users from famous class "#{famous_class[:name]}"...}
+        result = cached_get('api/trends/famouslist', classid: famous_class[:classid], subclassid: famous_class[:subclassid])
+        if result['ret'].to_i.zero?
+
+          unless result['data']
+            info "No results for famous class #{famous_class}"
+            next
+          end
+
+          result['data']['info'].each do |user|
+            sample_famous_user(user['account'])
+          end
+
+        else
+          error "Failed to sample users from famous class: #{famous_class}"
+        end
+
+        sleep SAMPLE_WAIT
+      end
+
+      info 'Finished famous users gathering'
+
+    rescue Error => e
+      error "Aborted famous users gathering: #{e.message}"
+    rescue => e
+      log_unexpected_error(e)
+    end
+
+    private
+
+    def sample_famous_user(user_name)
+      result = cached_get('api/user/other_info', name: user_name)
+
+      if result['ret'].to_i.zero? && result['data']
+        user = UserDecorator.decorate(result['data'])
+        publish_user(user, famous: true)
+      else
+        error %{Failed to gather profile of famous user "#{user_name}"}
+      end
+    end
+  end
+end

--- a/app/models/tencent_agent/users_sampling.rb
+++ b/app/models/tencent_agent/users_sampling.rb
@@ -59,12 +59,13 @@ class TencentAgent
       @keywords.delete(word)
     end
 
-    def publish_user(user)
+    def publish_user(user, famous: false)
       info %{Publishing user "#{user['name']}" openid: #{user['openid']}}
       PersonWorker.perform_async(
         target_source: 'tencent',
         target_id: user['openid'],
         target_name: user['name'],
+        famous: famous,
         birth_year: user['birth_year'],
         gender: user['gender'],
         city: user['city']

--- a/config/initializers/spider_scheduler.rb
+++ b/config/initializers/spider_scheduler.rb
@@ -7,6 +7,7 @@ class SpiderScheduler
     schedule_refresh_access_token
     # schedule_sample_users
     # schedule_track_users
+    # schedule_sample_famous_users
     schedule_gather_tweets
     schedule_reset_api_calls_count
   end
@@ -22,6 +23,12 @@ class SpiderScheduler
       TencentAgent.all.each do |agent|
         agent.gather_tweets
       end
+    end
+  end
+
+  def schedule_sample_famous_users
+    @scheduler.every '4w', first_in: '0s', mutex: :sample_famous_users do
+      TencentAgent.first.sample_famous_users
     end
   end
 
@@ -43,7 +50,7 @@ class SpiderScheduler
 
   def schedule_refresh_access_token
     @scheduler.every '1d', first_in: '0s', mutex:
-      [:sample_users, :track_users, :gather_tweets] do
+      [:sample_users, :sample_famous_users, :track_users, :gather_tweets] do
       TencentAgent.all.each do |agent|
         agent.refresh_access_token
       end

--- a/config/initializers/spider_scheduler.rb
+++ b/config/initializers/spider_scheduler.rb
@@ -38,15 +38,13 @@ class SpiderScheduler
     end
   end
 
-  # Switch to triggered by sample user
-  # def schedule_track_users
-  #   @scheduler.every '5m', first_in: '0s', mutex: :track_users do
-  #     TencentAgent.all.each do |agent|
-  #       next if agent[:full_with_lists]
-  #       agent.track_users
-  #     end
-  #   end
-  # end
+  def schedule_track_users
+    @scheduler.every '1y', first_in: '0s', mutex: :track_users do
+      TencentAgent.with_available_lists.each do |agent|
+        agent.track_users
+      end
+    end
+  end
 
   def schedule_refresh_access_token
     @scheduler.every '1d', first_in: '0s', mutex:

--- a/config/initializers/spider_scheduler.rb
+++ b/config/initializers/spider_scheduler.rb
@@ -20,7 +20,7 @@ class SpiderScheduler
 
   def schedule_gather_tweets
     @scheduler.every '30s', first_in: '0s', mutex: :gather_tweets do
-      TencentAgent.all.each do |agent|
+      TencentAgent.all.sort(created_at: :desc).each do |agent|
         agent.gather_tweets
       end
     end


### PR DESCRIPTION
It's just a quick & dirty solution for today's demo, so didn't turn on it in spider scheduler. I already run it on server manually, and ensure all tweets in latest week from these 904 famous people are gathered. It seems as we expected, these tweets didn't impact the trends explicitly, since 904/60k is a very low ratio.

Close #64 
