### PR TITLE
Spam

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,5 @@ pickle-email-*.html
 
 # Ignore data.json in development env
 /data/data.json
+/data/normal_corpus
+/data/spam_corpus

--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,7 @@ gem 'rails_admin'
 gem 'redis-rails'
 
 gem 'whenever', require: false
+gem 'judge', git: 'git://github.com/simsicon/judge.git'
 
 group :assets do
   gem 'sass-rails',   '~> 3.2.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -32,6 +32,13 @@ GIT
       oauth2 (~> 0.9.1)
 
 GIT
+  remote: git://github.com/simsicon/judge.git
+  revision: df5ebc3bf674dbac659a02f63ad9eea45a4f7a5e
+  specs:
+    judge (0.0.1)
+      rmmseg-cpp (~> 0.2.9)
+
+GIT
   remote: git://github.com/transist/fazscore.git
   revision: 3f1c34f59aac050f33a90a48e3087e27a8bdae03
   specs:
@@ -335,6 +342,7 @@ GEM
     remotipart (1.0.5)
     responders (0.9.3)
       railties (~> 3.1)
+    rmmseg-cpp (0.2.9)
     rspec (2.13.0)
       rspec-core (~> 2.13.0)
       rspec-expectations (~> 2.13.0)
@@ -450,6 +458,7 @@ DEPENDENCIES
   hiredis
   inherited_resources
   jquery-rails
+  judge!
   kiqstand
   launchy (>= 2.2.0)
   mocha

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,7 +33,7 @@ GIT
 
 GIT
   remote: git://github.com/simsicon/judge.git
-  revision: df5ebc3bf674dbac659a02f63ad9eea45a4f7a5e
+  revision: 6f737d14884a720a26012e913e42d582d87169e1
   specs:
     judge (0.0.1)
       rmmseg-cpp (~> 0.2.9)

--- a/app/workers/tweet_worker.rb
+++ b/app/workers/tweet_worker.rb
@@ -16,6 +16,8 @@ class TweetWorker
       TencentAgent.first.sample_user(target_person_id)
     end
 
+    person.spam! if Judge.spam? tweet_attrs[:content]
+
     person.tweets.create(tweet_attrs) unless person.spam?
   end
 end

--- a/lib/tasks/export_corpus_for_filter_spam.rake
+++ b/lib/tasks/export_corpus_for_filter_spam.rake
@@ -1,0 +1,44 @@
+desc 'Export corpus for filter spam'
+task export_corpus_for_filter_spam: :environment do
+
+  names = %w(yuLu365 vip520 xingzuoxuexing xingzuo360 gaoxiaophoto V5-Amm qinggans harry_lzx Quanqiuyinyue vipmood Q98704 vip520 xiaosile123 tanglang vip5200 vipmood Jaychina Mddongyuan Ndxxoo aliishuo Weisuomm zaoangod)
+  export_to = File.join(Rails.root, 'data', 'spam_corpus')
+  fetch_corpus(names, export_to)
+
+  names = %w(NBA han_qiaosheng liujianhong bashusong maoyushi yu_hua lianyue lvqiuluwei luoyonghao dogsun1970 mozhixuhu duqin8964 jsliming nandushendu reuters hu-shuli)
+  export_to = File.join(Rails.root, 'data', 'normal_corpus')
+  fetch_corpus(names, export_to)
+end
+
+def fetch_corpus(names, export_to)
+
+  t = TencentAgent.last
+
+  File.open(export_to, 'w') do |file|
+    
+    result = t.get('api/statuses/users_timeline', pageflag: 1, reqnum: 70, type: 3, names: names.join(','))
+
+    100.times do
+
+      if result['data']
+        result['data']['info'].each do |status|
+          text = status['text']
+          text = text + status['source']['text'] if status['source']
+          file.puts text
+        end
+
+        last_timestamp = result['data']['info'].last['timestamp']
+      else
+        puts "Fail to fetch from timestamp #{last_timestamp} #{result[:msg]}"
+        puts "Retrying..."
+      end
+
+      puts "Fetching from timestamp #{last_timestamp}...."
+
+      result = t.get('api/statuses/users_timeline', pageflag: 1, pagetime: last_timestamp, reqnum: 70, type: 3, names: names.join(','))
+
+      file.flush
+    end
+  end
+
+end


### PR DESCRIPTION
To filter Spam Users, based on the tencent spam users corpus, using https://github.com/simsicon/judge

need to run 

```
rake export_corpus_for_filter_spam
rake judge:train_and_export_corpus[normal_path,spam_path]
```

After deploy this commit.
