### PR TITLE
Tweak Z-Score calculation

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,7 +33,7 @@ GIT
 
 GIT
   remote: git://github.com/transist/fazscore.git
-  revision: 3f1c34f59aac050f33a90a48e3087e27a8bdae03
+  revision: 32ee50b3fd9e5a078f6e0db16f5f5cbc698b7267
   specs:
     fazscore (0.0.0)
 

--- a/app/assets/javascripts/panels.js.coffee
+++ b/app/assets/javascripts/panels.js.coffee
@@ -45,7 +45,7 @@ class Job
                          </tbody>
                         </table>
                         <table class='stats table table-striped'>
-                         <caption>Zero Trends</caption>
+                         <caption>Unusual Trends</caption>
                          <thead>
                            <tr>
                              <th>Keyword</th>
@@ -55,14 +55,14 @@ class Job
                            </tr>
                          </thead>
                          <tbody>
-                         {{#zero_stats}}
+                         {{#unusual_stats}}
                            <tr>
                              <td><a href='#' class='word'>{{word}}</a></td>
                              <td>{{score}}</td>
                              <td>{{current_stat}}</td>
                              <td><a href='#' class='stopword'><span class='icon-remove'></span></a></td>
                            </tr>
-                         {{/zero_stats}}
+                         {{/unusual_stats}}
                          </tbody>
                         </table>"
     @tweets_template = "<table class='tweets table table-striped'>
@@ -232,7 +232,7 @@ class Job
 
               $.each payload.positive_stats, $.proxy(self, 'updateHistoryStats', panelId, period)
               $.each payload.negative_stats, $.proxy(self, 'updateHistoryStats', panelId, period)
-              $.each payload.zero_stats, $.proxy(self, 'updateHistoryStats', panelId, period)
+              $.each payload.unusual_stats, $.proxy(self, 'updateHistoryStats', panelId, period)
 
               $(panelWidget).find('.trends').html $.mustache(self.trends_template, payload)
             $(panelWidget).find('.spinner').hide()

--- a/app/models/base_stat.rb
+++ b/app/models/base_stat.rb
@@ -77,7 +77,15 @@ class BaseStat
             end
           end
         end
-        Tweet.includes(:person).find(tweet_ids.to_a).map { |tweet| { id: tweet.id.to_s, person_id: tweet.person_id.to_s, target_id: tweet.target_id, content: tweet.content, posted_at: tweet.posted_at } unless tweet.spam || tweet.person.spam }.compact
+        Tweet.includes(:person).in(id: tweet_ids.to_a).map do |tweet|
+          {
+            id: tweet.id.to_s,
+            person_id: tweet.person_id.to_s,
+            target_id: tweet.target_id,
+            content: tweet.content,
+            posted_at: tweet.posted_at
+          } unless tweet.spam || tweet.person.spam
+        end.compact
       #end
     end
 

--- a/app/models/base_stat.rb
+++ b/app/models/base_stat.rb
@@ -37,7 +37,7 @@ class BaseStat
         measure_time = Time.now
         current_stats.each { |word, current_stat|
           unless user.has_stopword? word
-            z_score = FAZScore.new(0.5, history_stats[word].values[0..-2]).score(current_stat)
+            z_score = FAZScore.new(ENV['TRENDS_DECAY'].to_f, history_stats[word].values[0..-2]).score(current_stat)
             stat = {word: word, z_score: z_score, current_stat: current_stat, history_stats: history_stats[word]}
             if z_score > 0
               positive_stats << stat

--- a/config/application.example.yml
+++ b/config/application.example.yml
@@ -24,3 +24,6 @@ ECHIDNA_REDIS_HOST: 127.0.0.1
 ECHIDNA_REDIS_PORT: 6379
 
 DICT_DATA_JSON_PATH: /home/echidna/echidna.transi.st/shared/data.json
+
+# The decay must be in 0..1.
+TRENDS_DECAY: 0.5


### PR DESCRIPTION
Notable changes:
- Fix z-score algorithm to correctly treat very huge frequency changes as "Infinity" instead of zero.
- Skip words which have too low average and current frequency. Currently skip if word if it's average and current frequency lower than 4x overall average frequency.
- Replace meaningless zero stats with unusual stats. Currently we treat score above 10 as unusual. 

Close #100.
